### PR TITLE
add prune_gcc.sh script (and pruned ARM GCC 11.3 archive)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 filter=lfs diff=lfs merge=lfs -text
 arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz filter=lfs diff=lfs merge=lfs -text
+rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/prune_gcc.sh
+++ b/prune_gcc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Prune unused architectures from ARM GCC toolchain releases
+
+set -e
+
+# regex of architectures to retain
+ARCH_REGEX="nofp|v6-m|v7e-m(\+[df]p)?"
+# pruned archive prefix
+RUSEFI_PREFIX="rusefi-"
+# tar compression program
+COMPRESSION_PROGRAM="xz -T0 -9e"
+# compressed tarball suffix, needs to match $COMPRESSION_PROGRAM
+COMPRESSION_SUFFIX=".xz"
+# temporary working directory
+TMP_DIR="/tmp/rusefi-process_gcc"
+
+ARCHIVE="${1}"
+if [ -z "${1}" ]; then
+	echo "usage: ${0} ARCHIVE"
+	exit
+fi
+
+archive_tar="${ARCHIVE%.*}"
+rusefi_archive="${RUSEFI_PREFIX}${archive_tar}${COMPRESSION_SUFFIX}"
+
+# Cleanup prior [failed] runs
+rm -rf "${TMP_DIR}"
+
+# Extract original archive
+echo Extracting ${ARCHIVE}
+dir="$(pwd)"
+mkdir -p "${TMP_DIR}"
+tar -C "${TMP_DIR}" -xaf "${ARCHIVE}"
+pushd "${TMP_DIR}" >/dev/null
+archive_dir="$(echo *)"
+
+# Prune unused architecture objects
+pushd ${archive_dir} >/dev/null
+for path in arm-none-eabi/lib/thumb/*; do
+	arch="${path##*/}"
+	echo ${arch} | grep -Eq ${ARCH_REGEX} \
+		&& continue
+
+	echo Pruning architecture ${arch}
+
+	rm -rf arm-none-eabi/include/c++/*/arm-none-eabi/thumb/${arch}
+	rm -rf arm-none-eabi/lib/thumb/${arch}
+	rm -rf lib/gcc/arm-none-eabi/*/thumb/${arch}
+done
+popd >/dev/null
+
+# Create rusEFI archive
+echo Creating ${rusefi_archive}
+tar -I "${COMPRESSION_PROGRAM}" -cf "${dir}/${rusefi_archive}" "${archive_dir}"
+popd >/dev/null
+
+# Cleanup
+rm -rf "${TMP_DIR}"

--- a/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
+++ b/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c295cbaad4b41d36c94157571d59f133af1fa0f696e1a3b772a3bfb30d390b09
+size 180156268


### PR DESCRIPTION
Adds a script to prune unused architectures from a given ARM GCC toolchain tarball.

`$ ls -lah [6-9]e rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz`
```
-rw-r--r-- 1 nmschulte nmschulte 214M Nov  8 22:35 6e
-rw-r--r-- 1 nmschulte nmschulte 206M Nov  8 22:32 7e
-rw-r--r-- 1 nmschulte nmschulte 186M Nov  8 23:09 8e
-rw-r--r-- 1 nmschulte nmschulte 172M Nov  8 23:16 9e
-rw-r--r-- 1 nmschulte nmschulte 172M Nov  8 23:15 rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
```